### PR TITLE
nix: Allow M1

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
   };
 
   outputs = { self, hls, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin"] (system: let
+    flake-utils.lib.eachSystem ["x86_64-linux" "x86_64-darwin" "aarch64-darwin"] (system: let
 
       pkgs = import nixpkgs {
         inherit system;


### PR DESCRIPTION
At least `nix run` works on `aarch64-darwin`.