### PR TITLE
avoid switching directory in ihaskell-display

### DIFF
--- a/ihaskell-display/ihaskell-charts/ihaskell-charts.cabal
+++ b/ihaskell-display/ihaskell-charts/ihaskell-charts.cabal
@@ -58,6 +58,7 @@ library
                        bytestring,
                        data-default-class,
                        directory,
+                       temporary,
                        Chart,
                        Chart-cairo >=1.2,
                        ihaskell >= 0.6.2

--- a/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
+++ b/ihaskell-display/ihaskell-diagrams/ihaskell-diagrams.cabal
@@ -59,6 +59,7 @@ library
                        text,
                        bytestring,
                        directory,
+                       temporary,
                        -- Use diagrams wrapper package to ensure all same versions of subpackages
                        diagrams >= 1.3,
                        diagrams-lib,

--- a/ihaskell-display/ihaskell-gnuplot/IHaskell/Display/Gnuplot.hs
+++ b/ihaskell-display/ihaskell-gnuplot/IHaskell/Display/Gnuplot.hs
@@ -21,6 +21,7 @@ import qualified Graphics.Gnuplot.Terminal.SVG as Sv
 import qualified Graphics.Gnuplot.Graph.TwoDimensional as Tw
 import qualified Graphics.Gnuplot.Graph.ThreeDimensional as Th
 import qualified Data.ByteString.Char8 as Char
+import           System.IO.Temp
 import           Graphics.Gnuplot.Advanced (plot)
 import           Graphics.Gnuplot.Value.Atom (C)
 import           IHaskell.Display
@@ -58,9 +59,6 @@ instance IHaskellDisplay M.T where
     svgDisp <- graphDataSVGM fig
     return $ Display [pngDisp, svgDisp]
 
--- Filename
-name = ".ihaskell-gnuplot."
-
 -- Width and height
 w = 300
 
@@ -68,120 +66,110 @@ h = 300
 
 graphDataPNG2P :: (C x, C y) => P.T (Tw.T x y) -> IO DisplayData
 graphDataPNG2P graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.png" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Pn.cons $ name ++ "png"
-  plot fname graph
+    -- Write the image.
+    plot (Pn.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "png"
-  return $ png w h $ base64 imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ png w h $ base64 imgData
 
 graphDataSVG2P :: (C x, C y) => P.T (Tw.T x y) -> IO DisplayData
 graphDataSVG2P graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.svg" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Sv.cons $ name ++ "svg"
-  plot fname graph
+    -- Write the image.
+    plot (Sv.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "svg"
-  return $ svg $ Char.unpack imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ svg $ Char.unpack imgData
 
 graphDataPNG2F :: (C x, C y) => F.T (Tw.T x y) -> IO DisplayData
 graphDataPNG2F graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.png" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Pn.cons $ name ++ "png"
-  plot fname graph
+    -- Write the image.
+    plot (Pn.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "png"
-  return $ png w h $ base64 imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ png w h $ base64 imgData
 
 graphDataSVG2F :: (C x, C y) => F.T (Tw.T x y) -> IO DisplayData
 graphDataSVG2F graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.svg" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Sv.cons $ name ++ "svg"
-  plot fname graph
+    -- Write the image.
+    plot (Sv.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "svg"
-  return $ svg $ Char.unpack imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ svg $ Char.unpack imgData
 
 graphDataPNG3P :: (C x, C y, C z) => P.T (Th.T x y z) -> IO DisplayData
 graphDataPNG3P graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.png" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Pn.cons $ name ++ "png"
-  plot fname graph
+    -- Write the image.
+    plot (Pn.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "png"
-  return $ png w h $ base64 imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ png w h $ base64 imgData
 
 graphDataSVG3P :: (C x, C y, C z) => P.T (Th.T x y z) -> IO DisplayData
 graphDataSVG3P graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.svg" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Sv.cons $ name ++ "svg"
-  plot fname graph
+    -- Write the image.
+    plot (Sv.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "svg"
-  return $ svg $ Char.unpack imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ svg $ Char.unpack imgData
 
 graphDataPNG3F :: (C x, C y, C z) => F.T (Th.T x y z) -> IO DisplayData
 graphDataPNG3F graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.png" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Pn.cons $ name ++ "png"
-  plot fname graph
+    -- Write the image.
+    plot (Pn.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "png"
-  return $ png w h $ base64 imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ png w h $ base64 imgData
 
 graphDataSVG3F :: (C x, C y, C z) => F.T (Th.T x y z) -> IO DisplayData
 graphDataSVG3F graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.svg" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Sv.cons $ name ++ "svg"
-  plot fname graph
+    -- Write the image.
+    plot (Sv.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "svg"
-  return $ svg $ Char.unpack imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ svg $ Char.unpack imgData
 
 graphDataPNGM :: M.T -> IO DisplayData
 graphDataPNGM graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.png" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Pn.cons $ name ++ "png"
-  plot fname graph
+    -- Write the image.
+    plot (Pn.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "png"
-  return $ png w h $ base64 imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ png w h $ base64 imgData
 
 graphDataSVGM :: M.T -> IO DisplayData
 graphDataSVGM graph = do
-  switchToTmpDir
+  withSystemTempFile "ihaskell-gnuplot.svg" $ \path _ -> do
 
-  -- Write the image.
-  let fname = Sv.cons $ name ++ "svg"
-  plot fname graph
+    -- Write the image.
+    plot (Sv.cons path) graph
 
-  -- Read back, and convert to base64.
-  imgData <- Char.readFile $ name ++ "svg"
-  return $ svg $ Char.unpack imgData
+    -- Read back, and convert to base64.
+    imgData <- Char.readFile path
+    return $ svg $ Char.unpack imgData

--- a/ihaskell-display/ihaskell-gnuplot/ihaskell-gnuplot.cabal
+++ b/ihaskell-display/ihaskell-gnuplot/ihaskell-gnuplot.cabal
@@ -56,6 +56,7 @@ library
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.9 && <5,
                        bytestring,
+                       temporary,
                        gnuplot >= 0.5.4,
                        ihaskell >= 0.6.2
 

--- a/ihaskell-display/ihaskell-plot/ihaskell-plot.cabal
+++ b/ihaskell-display/ihaskell-plot/ihaskell-plot.cabal
@@ -57,6 +57,7 @@ library
   build-depends:       base >=4.9 && <5,
                        plot,
                        bytestring,
+                       temporary,
                        hmatrix >= 0.10,
                        ihaskell >= 0.6.2
 

--- a/src/IHaskell/Display.hs
+++ b/src/IHaskell/Display.hs
@@ -48,9 +48,6 @@ module IHaskell.Display (
     encode64,
     base64,
 
-    -- ** Utilities
-    switchToTmpDir,
-
     -- * Internal only use
     displayFromChanEncoded,
     serializeDisplay,
@@ -64,10 +61,8 @@ import qualified Data.ByteString.Lazy as LBS
 
 import           Data.Binary as Binary
 import qualified Data.ByteString.Base64 as Base64
-import           System.Directory (getTemporaryDirectory, setCurrentDirectory)
 
 import           Control.Concurrent.STM (atomically)
-import           Control.Exception (try)
 import           Control.Concurrent.STM.TChan
 import           System.IO.Unsafe (unsafePerformIO)
 
@@ -184,12 +179,3 @@ displayFromChanEncoded =
 -- execution call ends.
 printDisplay :: IHaskellDisplay a => a -> IO ()
 printDisplay disp = display disp >>= atomically . writeTChan displayChan
-
--- | Convenience function for client libraries. Switch to a temporary directory so that any files we
--- create aren't visible. On Unix, this is usually /tmp.
-switchToTmpDir :: IO ()
-switchToTmpDir = void (try switchDir :: IO (Either SomeException ()))
-  where
-    switchDir =
-      getTemporaryDirectory >>=
-      setCurrentDirectory


### PR DESCRIPTION
related: #1358 

I removed the function `switchToTmpDir` and replaced every usage of it with `withSystemTempFile`.