### PR TITLE
Add -dynamic back in; removal broke IHaskell

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -136,7 +136,11 @@ executable ihaskell
   hs-source-dirs: main
   other-modules:
                    Paths_ihaskell
-  ghc-options: -threaded -rtsopts -Wall
+  -- NB Without -dynamic IHaskell loads every package statically on startup
+  -- This makes startup incredibly slow on large projects
+  -- Without -dynamic IHaskell also cannot load shared libraries
+  -- This leads to users getting cryptic error messages about missing symbols
+  ghc-options: -threaded -rtsopts -Wall -dynamic
 
   if os(darwin)
     ghc-options: -optP-Wno-nonportable-include-path


### PR DESCRIPTION
This commit removed `-dynamic` as a default flag https://github.com/IHaskell/IHaskell/commit/2891bc8498ce12ae2677d72c7252e2623158e378

The results of this change break IHaskell in two ways. First, it now links every package available statically on startup. This is fine for small projects. In a large project though, with 200 packages, I gave up after 15 minutes. Second, many of us use IHaskell with packages that rely on shared libraries. This stopped working entirely.

There's a related long discussion here
https://github.com/IHaskell/IHaskell/pull/1252/files#diff-30f4411ae6041ebe629c055ae5c4407e47989f719a5733416bfa23454270ba65R130

The suggested solution is that users should add dynamic in this case. But there is simply no way for users to figure this out.

I had to run strace and notice among its 100Mb of output that ihaskell is stuck loading one object file after another and look at gdb to confirm that it's stuck in the linker pinning the CPU to 100%. No one is going to do this and then realize that -dynamic is needed in IHaskell.

But it's even worse for a small project. You will inexplicably get errors about shared libraries. And they'll be lazy! So most of the code works, until you trip over some code that uses the shared library and then you get an incredibly cryptic error about symbols missing. Users have absolutely no way of tracking this back to IHaskell, never mind realizing that they need to add -dynamic.

This was done to make building docker images simpler. https://github.com/IHaskell/IHaskell/pull/1252

All of this is a horrible cost to pay for some convenience when building docker images. It breaks the common case for a slightly more convenient corner case. The downside of this pull request is it breaks building the Docker images, would you mind fixing that @brandon-leapyear? You seemed to have a version that copies over the right files.

I suggest we add -dynamic back in. @junjihashimoto suggested the same in the discussion above.