### PR TITLE
Stack lts-20.5 (ghc-9.2.5) works better with Mac M1

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ ihaskell install --stack
 
 If you have Homebrew installed to a location that `stack` does not expect (e.g. `/opt/homebrew`), you'd need to specify `--extra-include-dirs ${HOMEBREW_PREFIX}/include --extra-lib-dirs ${HOMEBREW_PREFIX}/lib` to the `stack` command.
 
+If you have a MacOS 13 running on a M1 Mac, select version 9.2 of YAML configuration file by specifying `--stack-yaml stack-9.2.yaml` to the `stack` command. 
+
 Run Jupyter.
 
 ```bash

--- a/stack-9.2.yaml
+++ b/stack-9.2.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2022-09-11 # GHC 9.2.4
+resolver: lts-20.5 # GHC 9.2.5
 
 flags: {}
 packages:


### PR DESCRIPTION
GHC 9.2.5 fixes [bug #21964](https://gitlab.haskell.org/ghc/ghc/-/issues/21964) that affects M1 Macs running MacOS 13, and it's now included in Stack as LTS-20.5.