### PR TITLE
.github/workflows/ci.yml: update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         # above pass, it's unlikely that we'll introduce a bug that we will
         # only catch through the integration test on this version and not other
         # versions.
-        if: ${{ matrix.versions.stack-yaml != 'stack-8.0.yaml' }}
+        if: ${{ contains(fromJSON('["stack-8.0.yaml", "stack-8.2.yaml", "stack-8.4.yaml"]'), matrix.versions.stack-yaml) }}
         run: |
           set -e
           stack build --no-terminal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         # above pass, it's unlikely that we'll introduce a bug that we will
         # only catch through the integration test on this version and not other
         # versions.
-        if: ${{ contains(fromJSON('["stack-8.0.yaml", "stack-8.2.yaml", "stack-8.4.yaml"]'), matrix.versions.stack-yaml) }}
+        if: ${{ !contains(fromJSON('["stack-8.0.yaml", "stack-8.2.yaml", "stack-8.4.yaml"]'), matrix.versions.stack-yaml) }}
         run: |
           set -e
           stack build --no-terminal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
         # above pass, it's unlikely that we'll introduce a bug that we will
         # only catch through the integration test on this version and not other
         # versions.
-        if: ${{ !contains(fromJSON('["stack-8.0.yaml", "stack-8.2.yaml", "stack-8.4.yaml"]'), matrix.versions.stack-yaml) }}
+        if: ${{ !contains(fromJSON('["stack-8.0.yaml"]'), matrix.versions.stack-yaml) }}
         run: |
           set -e
           stack build --no-terminal

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -7,25 +7,17 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    - ./ihaskell-display/ihaskell-charts
-    - ./ihaskell-display/ihaskell-diagrams
+    # - ./ihaskell-display/ihaskell-charts
+    # - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-hatex
     - ./ihaskell-display/ihaskell-juicypixels
     - ./ihaskell-display/ihaskell-magic
-    - ./ihaskell-display/ihaskell-plot
+    # - ./ihaskell-display/ihaskell-plot
     - ./ihaskell-display/ihaskell-static-canvas
     - ./ihaskell-display/ihaskell-widgets
 
-extra-deps:
-- plot-0.2.3.9
-- Chart-cairo-1.9.1
-- diagrams-cairo-1.4.1
-- cairo-0.13.6.0
-- pango-0.13.6.1
-- glib-0.13.7.1
-- gtk2hs-buildtools-0.13.5.4
-- magic-1.1
+extra-deps: []
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Werror

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -7,8 +7,8 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    - ./ihaskell-display/ihaskell-charts
-    - ./ihaskell-display/ihaskell-diagrams
+    # - ./ihaskell-display/ihaskell-charts
+    # - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-hatex
     - ./ihaskell-display/ihaskell-juicypixels

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -7,8 +7,8 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    # - ./ihaskell-display/ihaskell-charts
-    # - ./ihaskell-display/ihaskell-diagrams
+    - ./ihaskell-display/ihaskell-charts
+    - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-hatex
     - ./ihaskell-display/ihaskell-juicypixels
@@ -17,7 +17,15 @@ packages:
     - ./ihaskell-display/ihaskell-static-canvas
     - ./ihaskell-display/ihaskell-widgets
 
-extra-deps: []
+extra-deps:
+- plot-0.2.3.9
+- Chart-cairo-1.9.1
+- diagrams-cairo-1.4.1
+- cairo-0.13.6.0
+- pango-0.13.6.1
+- glib-0.13.7.1
+- gtk2hs-buildtools-0.13.5.4
+- magic-1.1
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Werror

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -7,8 +7,8 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    # - ./ihaskell-display/ihaskell-charts
-    # - ./ihaskell-display/ihaskell-diagrams
+    - ./ihaskell-display/ihaskell-charts
+    - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-graphviz
     - ./ihaskell-display/ihaskell-hatex
@@ -27,19 +27,25 @@ ghc-options:
 allow-newer: true
 
 extra-deps:
-- static-canvas-0.2.0.3
+- Chart-cairo-1.9.1
+- cairo-0.13.6.0
+- cubicbezier-0.6.0.5
 - diagrams-1.4
-- diagrams-cairo-1.4
-- diagrams-lib-1.4.2
-- magic-1.1
+- diagrams-cairo-1.4.1
 - diagrams-contrib-1.4.2.1
 - diagrams-core-1.4.0.1
+- diagrams-lib-1.4.2
 - diagrams-solve-0.1.1
 - diagrams-svg-1.4.1.1
 - dual-tree-0.2.1
-- cubicbezier-0.6.0.5
-- mfsolve-0.3.2.0
 - fast-math-1.0.2
+- glib-0.13.7.1
+- gtk2hs-buildtools-0.13.5.4
+- magic-1.1
+- mfsolve-0.3.2.0
+- pango-0.13.6.1
+- plot-0.2.3.9
+- static-canvas-0.2.0.3
 
 nix:
   enable: false

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -7,8 +7,8 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    - ./ihaskell-display/ihaskell-charts
-    - ./ihaskell-display/ihaskell-diagrams
+    # - ./ihaskell-display/ihaskell-charts
+    # - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-graphviz
     - ./ihaskell-display/ihaskell-hatex

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -7,8 +7,8 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    # - ./ihaskell-display/ihaskell-charts
-    # - ./ihaskell-display/ihaskell-diagrams
+    - ./ihaskell-display/ihaskell-charts
+    - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-hatex
     - ./ihaskell-display/ihaskell-juicypixels
@@ -18,10 +18,14 @@ packages:
     - ./ihaskell-display/ihaskell-widgets
 
 extra-deps:
-- magic-1.1
-- Chart-1.9
-- Chart-cairo-1.9
 - plot-0.2.3.9
+- Chart-cairo-1.9.1
+- diagrams-cairo-1.4.1
+- cairo-0.13.6.0
+- pango-0.13.6.1
+- glib-0.13.7.1
+- gtk2hs-buildtools-0.13.5.4
+- magic-1.1
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Wpartial-fields -Werror

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -7,8 +7,8 @@ packages:
     - ./ghc-parser
     - ./ihaskell-display/ihaskell-aeson
     - ./ihaskell-display/ihaskell-blaze
-    - ./ihaskell-display/ihaskell-charts
-    - ./ihaskell-display/ihaskell-diagrams
+    # - ./ihaskell-display/ihaskell-charts
+    # - ./ihaskell-display/ihaskell-diagrams
     - ./ihaskell-display/ihaskell-gnuplot
     - ./ihaskell-display/ihaskell-hatex
     - ./ihaskell-display/ihaskell-juicypixels

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -20,6 +20,7 @@ packages:
 extra-deps:
 - plot-0.2.3.9
 - Chart-cairo-1.9.1
+- Chart-1.9.4
 - diagrams-cairo-1.4.1
 - cairo-0.13.6.0
 - pango-0.13.6.1


### PR DESCRIPTION
GitHub Actions has stopped providing `ubuntu-18.04` runners, so our Stack CI times out and fails. The reason we were using these runners is because the versions of dependencies such as `cairo` provided in LTS releases for GHC 8.4 and below do not build correctly on Ubuntu 20.04 onwards. Getting everything building again required some `extra-deps` finagling, but we might be able to keep the integration tests enabled for 8.2 and 8.4 (they were already disabled for 8.0 due to flakiness).