### PR TITLE
Remove `here` dependency

### DIFF
--- a/ihaskell.cabal
+++ b/ihaskell.cabal
@@ -189,7 +189,6 @@ Test-Suite hspec
         directory,
         text,
         ihaskell,
-        here,
         hspec,
         hspec-contrib,
         HUnit,

--- a/src/tests/IHaskell/Test/Eval.hs
+++ b/src/tests/IHaskell/Test/Eval.hs
@@ -11,7 +11,7 @@ import           Data.Aeson (encode)
 import           Data.IORef (newIORef, modifyIORef, readIORef)
 import           System.Directory (getTemporaryDirectory, setCurrentDirectory)
 
-import           Data.String.Here (hereLit)
+import           Text.RawString.QQ (r)
 
 import qualified GHC.Paths
 
@@ -87,7 +87,7 @@ testEval =
       "3" `becomes` ["3"]
       "3+5" `becomes` ["8"]
       "print 3" `becomes` ["3"]
-      [hereLit|
+      [r|
         let x = 11
             z = 10 in
           x+z
@@ -100,14 +100,14 @@ testEval =
     --   ":set -XNoImplicitPrelude" `becomes` []
 
     it "evaluates multiline expressions" $ do
-      [hereLit|
+      [r|
         import Control.Monad
         forM_ [1, 2, 3] $ \x ->
           print x
       |] `becomes` ["1\n2\n3"]
 
     it "evaluates function declarations silently" $ do
-      [hereLit|
+      [r|
         fun :: [Int] -> Int
         fun [] = 3
         fun (x:xs) = 10
@@ -115,7 +115,7 @@ testEval =
       |] `becomes` ["10"]
 
     it "evaluates data declarations" $ do
-      [hereLit|
+      [r|
         data X = Y Int
                | Z String
                deriving (Show, Eq)
@@ -124,7 +124,7 @@ testEval =
       |] `becomes` ["[Y 3,Z \"No\"]", "False"]
 
     it "evaluates do blocks in expressions" $ do
-      [hereLit|
+      [r|
         show (show (do
             Just 10
             Nothing
@@ -191,13 +191,13 @@ testEval =
 #endif
 
     it "captures stderr" $ do
-      [hereLit|
+      [r|
         import Debug.Trace
         trace "test" 5
       |] `becomes` ["test\n5"]
 
     it "immediately applies language extensions" $ do
-      [hereLit|
+      [r|
         {-# LANGUAGE RankNTypes #-}
 
         identity :: forall a. a -> a

--- a/src/tests/IHaskell/Test/Parser.hs
+++ b/src/tests/IHaskell/Test/Parser.hs
@@ -4,7 +4,7 @@ module IHaskell.Test.Parser (testParser) where
 
 import           Prelude
 
-import           Data.String.Here (hereLit)
+import           Text.RawString.QQ (r)
 
 import           Test.Hspec
 import           Test.HUnit (assertFailure)
@@ -47,7 +47,7 @@ testLayoutChunks = describe "Layout Chunk" $ do
     map unloc (layoutChunks "a\n\nstring") `shouldBe` ["a", "string"]
 
   it "parses multiple exprs" $ do
-    let text = [hereLit|
+    let text = [r|
                  first
 
                  second
@@ -201,7 +201,7 @@ testParseString = describe "Parser" $ do
     parses "import X\nprint 3" `like` [Import "import X", Expression "print 3"]
     parses "import X\n\nprint 3" `like` [Import "import X", Expression "print 3"]
   it "ignores blank lines properly" $
-    [hereLit|
+    [r|
       test arg = hello
         where
           x = y
@@ -213,7 +213,7 @@ testParseString = describe "Parser" $ do
     ("img ! src \"" ++ longString ++ "\" ! width \"500\"") `is` Expression
 
   it "parses do blocks in expression" $ do
-    [hereLit|
+    [r|
       show (show (do
         Just 10
         Nothing
@@ -221,7 +221,7 @@ testParseString = describe "Parser" $ do
     |] `is` Expression
   it "correctly locates parsed items" $ do
     ghc (parseString
-      [hereLit|
+      [r|
         first
 
         second


### PR DESCRIPTION
We were already using `raw-strings-qq` which is a drop-in replacement.