### PR TITLE
flake: use a more recent GHC, and set mainProgram = "jupyter-lab" for envs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
         }
       ) envs;
 
-      defaultPackage = self.packages.${system}.ihaskell-ghc810;
+      defaultPackage = self.packages.${system}.ihaskell-env-ghc94;
 
       devShell = self.packages.${system}.ihaskell-dev-ghc810;
     });

--- a/nix/release.nix
+++ b/nix/release.nix
@@ -106,4 +106,8 @@ buildEnv {
                   then haskell.lib.justStaticExecutables haskellPackages.ihaskell
                   else haskell.lib.enableSharedExecutables haskellPackages.ihaskell;
   };
+
+  meta = {
+    mainProgram = "jupyter-lab";
+  };
 }


### PR DESCRIPTION
Just putting this out here -- this change will allow you to run

```shell
nix run github:IHaskell/IHaskell
```

and you'll get a working JupyterLab, which is pretty cool I think. I picked GHC 9.4 as the default since it's the latest current Stackage LTS. You can also pick the variant you want like this:

```shell
nix run github:IHaskell/IHaskell#ihaskell-env-display-ghc96
```

With this we could modernize the Nix section of the docs, which currently uses `nix-build` and pulls a random Nixpkgs 23.05 tarball. We could also put a [binary cache flake hint](https://nixos.wiki/wiki/Binary_Cache#Binary_cache_hint_in_Flakes) and then it would be easy for people to use the Cachix artifacts.

Maybe we also want to shorten the flake output names for the environments--perhaps like `ghc96-base` for the base environment, and `ghc96-full` for the full environment.

