### PR TITLE
.github/workflows/stack-nix.yml: don't test 8.8

### DIFF
--- a/.github/workflows/stack-nix.yml
+++ b/.github/workflows/stack-nix.yml
@@ -44,7 +44,7 @@ jobs:
         # - 'stack/stack-8.2.yaml'
         # - 'stack/stack-8.4.yaml'
         # - 'stack/stack-8.6.yaml'
-        - 'stack/stack-8.8.yaml'
+        # - 'stack/stack-8.8.yaml'
         - 'stack/stack-8.10.yaml'
         - 'stack/stack-9.0.yaml'
         - 'stack/stack-9.2.yaml'
@@ -77,13 +77,11 @@ jobs:
         stack build --nix --stack-yaml ${{matrix.stack-yaml}}
 
     - name: Test
-      if: ${{ !contains(fromJSON('["stack/stack-8.8.yaml"]'), matrix.stack-yaml) }}
       run: |
         export "NIX_PATH=nixpkgs=$(nix run .#print-nixpkgs-master)"
         stack test --nix --stack-yaml ${{matrix.stack-yaml}}
 
     - name: Run integration test
-      if: ${{ !contains(fromJSON('["stack/stack-8.8.yaml"]'), matrix.stack-yaml) }}
       run: |
         set -e
 


### PR DESCRIPTION
The build is broken because Stack wants `ghc884` but Nixpkgs doesn't provide it. This seems like an upstream issue and cannot be fixed by us.