### PR TITLE
Reinstate tests for GHC <= 8.6

### DIFF
--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -85,11 +85,11 @@ jobs:
         stack test --stack-yaml ${{matrix.stack-yaml}}
 
     - name: Run integration test
-      # The test is flaky on GHC 8.0 so we don't run it. As long as the tests
-      # above pass, it's unlikely that we'll introduce a bug that we will
+      # The test is flaky on GHC 8.0 and 8.2 so we don't run it. As long as the
+      # tests above pass, it's unlikely that we'll introduce a bug that we will
       # only catch through the integration test on this version and not other
       # versions.
-      if: ${{ !contains(fromJSON('["stack/stack-8.0.yaml"]'), matrix.stack-yaml) }}
+      if: ${{ !contains(fromJSON('["stack/stack-8.0.yaml", "stack/stack-8.2.yaml"]'), matrix.stack-yaml) }}
       run: |
         nix build .#jupyterlab
         export PATH="$(pwd)/result/bin:$(pwd)/.local/bin:$PATH"

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -81,7 +81,6 @@ jobs:
         stack build --stack-yaml ${{matrix.stack-yaml}}
 
     - name: Test
-      if: ${{ !contains(fromJSON('["stack/stack-8.8.yaml"]'), matrix.stack-yaml) }}
       run: |
         stack test --stack-yaml ${{matrix.stack-yaml}}
 

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/stack.yml
+++ b/.github/workflows/stack.yml
@@ -39,9 +39,10 @@ jobs:
       fail-fast: false
       matrix:
         stack-yaml:
-        # - 'stack/stack-8.2.yaml'
-        # - 'stack/stack-8.4.yaml'
-        # - 'stack/stack-8.6.yaml'
+        - 'stack/stack-8.0.yaml'
+        - 'stack/stack-8.2.yaml'
+        - 'stack/stack-8.4.yaml'
+        - 'stack/stack-8.6.yaml'
         - 'stack/stack-8.8.yaml'
         - 'stack/stack-8.10.yaml'
         - 'stack/stack-9.0.yaml'
@@ -89,7 +90,7 @@ jobs:
       # above pass, it's unlikely that we'll introduce a bug that we will
       # only catch through the integration test on this version and not other
       # versions.
-      if: ${{ !contains(fromJSON('["stack/stack-8.0.yaml", "stack/stack-8.2.yaml"]'), matrix.stack-yaml) }}
+      if: ${{ !contains(fromJSON('["stack/stack-8.0.yaml"]'), matrix.stack-yaml) }}
       run: |
         nix build .#jupyterlab
         export PATH="$(pwd)/result/bin:$(pwd)/.local/bin:$PATH"

--- a/stack/stack-8.0.yaml
+++ b/stack/stack-8.0.yaml
@@ -1,20 +1,20 @@
 resolver: lts-9.21
 
 packages:
-    - .
-    - ./ipython-kernel
-    - ./ghc-parser
-    - ./ihaskell-display/ihaskell-aeson
-    - ./ihaskell-display/ihaskell-blaze
+    - ..
+    - ../ipython-kernel
+    - ../ghc-parser
+    - ../ihaskell-display/ihaskell-aeson
+    - ../ihaskell-display/ihaskell-blaze
     # - ./ihaskell-display/ihaskell-charts
     # - ./ihaskell-display/ihaskell-diagrams
-    - ./ihaskell-display/ihaskell-gnuplot
-    - ./ihaskell-display/ihaskell-hatex
-    - ./ihaskell-display/ihaskell-juicypixels
-    - ./ihaskell-display/ihaskell-magic
+    - ../ihaskell-display/ihaskell-gnuplot
+    - ../ihaskell-display/ihaskell-hatex
+    - ../ihaskell-display/ihaskell-juicypixels
+    - ../ihaskell-display/ihaskell-magic
     # - ./ihaskell-display/ihaskell-plot
-    - ./ihaskell-display/ihaskell-static-canvas
-    - ./ihaskell-display/ihaskell-widgets
+    - ../ihaskell-display/ihaskell-static-canvas
+    - ../ihaskell-display/ihaskell-widgets
 
 extra-deps: []
 

--- a/stack/stack-8.2.yaml
+++ b/stack/stack-8.2.yaml
@@ -1,21 +1,21 @@
 resolver: lts-11.22
 
 packages:
-- .
-- ./ipython-kernel
-- ./ghc-parser
-- ./ihaskell-display/ihaskell-aeson
-- ./ihaskell-display/ihaskell-blaze
-- ./ihaskell-display/ihaskell-charts
-- ./ihaskell-display/ihaskell-diagrams
-- ./ihaskell-display/ihaskell-gnuplot
-- ./ihaskell-display/ihaskell-graphviz
-- ./ihaskell-display/ihaskell-hatex
-- ./ihaskell-display/ihaskell-juicypixels
-- ./ihaskell-display/ihaskell-magic
-- ./ihaskell-display/ihaskell-plot
-- ./ihaskell-display/ihaskell-static-canvas
-- ./ihaskell-display/ihaskell-widgets
+- ..
+- ../ipython-kernel
+- ../ghc-parser
+- ../ihaskell-display/ihaskell-aeson
+- ../ihaskell-display/ihaskell-blaze
+- ../ihaskell-display/ihaskell-charts
+- ../ihaskell-display/ihaskell-diagrams
+- ../ihaskell-display/ihaskell-gnuplot
+- ../ihaskell-display/ihaskell-graphviz
+- ../ihaskell-display/ihaskell-hatex
+- ../ihaskell-display/ihaskell-juicypixels
+- ../ihaskell-display/ihaskell-magic
+- ../ihaskell-display/ihaskell-plot
+- ../ihaskell-display/ihaskell-static-canvas
+- ../ihaskell-display/ihaskell-widgets
 
 ghc-options:
   # Eventually we want "$locals": -Wall -Werror

--- a/stack/stack-8.4.yaml
+++ b/stack/stack-8.4.yaml
@@ -1,20 +1,20 @@
 resolver: lts-12.26
 
 packages:
-- .
-- ./ipython-kernel
-- ./ghc-parser
-- ./ihaskell-display/ihaskell-aeson
-- ./ihaskell-display/ihaskell-blaze
-- ./ihaskell-display/ihaskell-charts
-- ./ihaskell-display/ihaskell-diagrams
-- ./ihaskell-display/ihaskell-gnuplot
-- ./ihaskell-display/ihaskell-hatex
-- ./ihaskell-display/ihaskell-juicypixels
-- ./ihaskell-display/ihaskell-magic
-- ./ihaskell-display/ihaskell-plot
-- ./ihaskell-display/ihaskell-static-canvas
-- ./ihaskell-display/ihaskell-widgets
+- ..
+- ../ipython-kernel
+- ../ghc-parser
+- ../ihaskell-display/ihaskell-aeson
+- ../ihaskell-display/ihaskell-blaze
+- ../ihaskell-display/ihaskell-charts
+- ../ihaskell-display/ihaskell-diagrams
+- ../ihaskell-display/ihaskell-gnuplot
+- ../ihaskell-display/ihaskell-hatex
+- ../ihaskell-display/ihaskell-juicypixels
+- ../ihaskell-display/ihaskell-magic
+- ../ihaskell-display/ihaskell-plot
+- ../ihaskell-display/ihaskell-static-canvas
+- ../ihaskell-display/ihaskell-widgets
 
 extra-deps:
 - plot-0.2.3.9


### PR DESCRIPTION
I don't know why these were disabled.