### PR TITLE
.github/workflows/stack-nix.yml: use different cache key

### DIFF
--- a/.github/workflows/stack-nix.yml
+++ b/.github/workflows/stack-nix.yml
@@ -69,7 +69,7 @@ jobs:
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-${{ matrix.stack-yaml }}-${{ hashFiles(format('./{0}', matrix.stack-yaml)) }}
+        key: ${{ runner.os }}-${{ matrix.stack-yaml }}-nix-${{ hashFiles(format('./{0}', matrix.stack-yaml)) }}
 
     - name: Build
       run: |


### PR DESCRIPTION
I don't think it makes sense to use the same cache key here, since the Nix and non-Nix builds can't share caches.