### PR TITLE
.github/workflows/stack-nix.yml: don't test stack.yaml separately

### DIFF
--- a/.github/workflows/stack-nix.yml
+++ b/.github/workflows/stack-nix.yml
@@ -50,7 +50,6 @@ jobs:
         - 'stack/stack-9.2.yaml'
         - 'stack/stack-9.4.yaml'
         - 'stack/stack-9.6.yaml'
-        - 'stack.yaml'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
It's identical to `stack/stack-9.4.yaml` except for relative paths so I don't see the need to test both.