### PR TITLE
Bring back Nix 9.0, 9.2 using magic cache

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -33,18 +33,33 @@ on:
 jobs:
   build:
     if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork)
+    name: "${{matrix.env.name}} (Cachix: ${{matrix.env.cachix}})"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         env:
-        - ihaskell-env-ghc94
-        - ihaskell-env-ghc96
-        - ihaskell-env-ghc98
+        - name: ihaskell-env-ghc90
+          cachix: false
+        - name: ihaskell-env-ghc92
+          cachix: false
+        - name: ihaskell-env-ghc94
+          cachix: true
+        - name: ihaskell-env-ghc96
+          cachix: true
+        - name: ihaskell-env-ghc98
+          cachix: true
 
-        - ihaskell-env-display-ghc94
-        - ihaskell-env-display-ghc96
-        - ihaskell-env-display-ghc98
+        - name: ihaskell-env-display-ghc90
+          cachix: false
+        - name: ihaskell-env-display-ghc92
+          cachix: false
+        - name: ihaskell-env-display-ghc94
+          cachix: true
+        - name: ihaskell-env-display-ghc96
+          cachix: true
+        - name: ihaskell-env-display-ghc98
+          cachix: true
 
     steps:
     - uses: actions/checkout@v3
@@ -53,19 +68,24 @@ jobs:
       with:
         install_url: https://releases.nixos.org/nix/nix-2.19.2/install
 
+    # Cache with either Cachix or the magic Nix cache, depending on the matrix.
+    # The latter uses only GitHub Actions storage.
     - uses: cachix/cachix-action@v12
+      if: ${{ matrix.env.cachix }}
       with:
         name: ihaskell
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - uses: DeterminateSystems/magic-nix-cache-action@main
+      if: ${{ !matrix.env.cachix }}
 
-    - name: Build environment ${{matrix.env}}
+    - name: "Build environment ${{matrix.env.name}} (Cachix: ${{matrix.env.cachix}})"
       run: |
-        nix build .#${{matrix.env}}
+        nix build .#${{matrix.env.name}}
 
-    - name: Check acceptance test for ${{matrix.env}}
+    - name: Check acceptance test for ${{matrix.env.name}}
       # Disable GHC 9.8 here since we don't have hlint support yet
       # Also, don't bother running it with the display envs since we already run it with the
       # basic envs, and it doesn't test any display stuff.
-      if: ${{ !contains(fromJSON('["ihaskell-env-ghc98"]'), matrix.env) && !contains(matrix.env, fromJSON('"display"')) }}
+      if: ${{ !contains(fromJSON('["ihaskell-env-ghc98"]'), matrix.env.name) && !contains(matrix.env.name, fromJSON('"display"')) }}
       run: |
-        nix build .#checks.x86_64-linux.${{matrix.env}} -L
+        nix build .#checks.x86_64-linux.${{matrix.env.name}} -L

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,8 @@
         };
         in
           pkgsMaster.lib.listToAttrs [
+            (mkVersion nixpkgs23_11  "ghc90"  [(import ./nix/overlay-9.0.nix)]  {})
+            (mkVersion nixpkgs23_11  "ghc92"  [(import ./nix/overlay-9.2.nix)]  {})
             (mkVersion nixpkgs23_11  "ghc94"  [(import ./nix/overlay-9.4.nix)]  {})
             (mkVersion nixpkgsMaster "ghc96"  [(import ./nix/overlay-9.6.nix)]  {})
             (mkVersion nixpkgsMaster "ghc98"  [(import ./nix/overlay-9.8.nix)]  { enableHlint = false; })
@@ -103,6 +105,6 @@
 
       defaultPackage = self.packages.${system}.ihaskell-env-ghc94;
 
-      devShell = self.packages.${system}.ihaskell-dev-ghc810;
+      devShell = self.packages.${system}.ihaskell-dev-ghc94;
     });
 }

--- a/nix/overlay-9.0.nix
+++ b/nix/overlay-9.0.nix
@@ -1,0 +1,14 @@
+sel: sup: {
+  haskell = sup.haskell // {
+    packages = sup.haskell.packages // {
+      ghc90 = sup.haskell.packages.ghc90.override {
+        overrides = self: super: {
+          singletons-base = self.callHackage "singletons-base" "3.0" {};
+          singletons-th = self.callHackage "singletons-th" "3.0" {};
+          th-desugar = self.callHackage "th-desugar" "1.12" {};
+          Chart-cairo = self.callHackage "Chart-cairo" "1.9.3" {};
+        };
+      };
+    };
+  };
+}

--- a/nix/overlay-9.2.nix
+++ b/nix/overlay-9.2.nix
@@ -1,0 +1,15 @@
+sel: sup: {
+  haskell = sup.haskell // {
+    packages = sup.haskell.packages // {
+      ghc92 = sup.haskell.packages.ghc92.override {
+        overrides = self: super: {
+          singletons-base = self.callHackage "singletons-base" "3.1" {};
+          singletons-th = self.callHackage "singletons-th" "3.1" {};
+          singletons = self.callHackage "singletons" "3.0.1" {};
+          th-desugar = self.callHackage "th-desugar" "1.13.1" {};
+          Chart-cairo = self.callHackage "Chart-cairo" "1.9.3" {};
+        };
+      };
+    };
+  };
+}


### PR DESCRIPTION
This demonstrates using the `DeterminateSystems/magic-nix-cache-action` in place of Cachix for certain builds, and brings back GHC 9.0 and 9.2 in the Nix CI to use it. 

It's fast, with a full Nix workflow build taking 2-3 minutes in my tests.

Hopefully this is a satisfactory way to maintain Nix support for these compilers without using too many Cachix resources.