### PR TITLE
.github/workflows/nix.yml: use latest nixpkgs 23.11

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -58,6 +58,9 @@ jobs:
         name: ihaskell
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
 
+    - name: Use latest Nixpkgs 23.11
+      run: nix flake update nixpkgs23_11
+
     - name: Build environment ${{matrix.env}}
       run: |
         nix build .#${{matrix.env}}


### PR DESCRIPTION
This is so that the cache is populated with binaries that are more likely to correspond to those that users actually want, instead of being limited to a stale version of Nixpkgs.