### PR TITLE
ihaskell-aeson: remove `here` dependency

### DIFF
--- a/ihaskell-display/ihaskell-aeson/IHaskell/Display/Aeson.hs
+++ b/ihaskell-display/ihaskell-aeson/IHaskell/Display/Aeson.hs
@@ -8,7 +8,6 @@ import           Data.Text.Encoding as E
 
 import           Data.Aeson
 import           Data.Aeson.Encode.Pretty
-import           Data.String.Here
 
 import           IHaskell.Display
 

--- a/ihaskell-display/ihaskell-aeson/ihaskell-aeson.cabal
+++ b/ihaskell-display/ihaskell-aeson/ihaskell-aeson.cabal
@@ -54,7 +54,6 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base >=4.9 && <5,
-                       here,
                        text,
                        bytestring,
                        aeson >= 0.7,


### PR DESCRIPTION
It was unused.