### PR TITLE
.github/workflows/nix.yml: bump cachix action

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         install_url: https://releases.nixos.org/nix/nix-2.19.2/install
 
-    - uses: cachix/cachix-action@v12
+    - uses: cachix/cachix-action@v14
       with:
         name: ihaskell
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
This uses the new daemon mode that pushes store paths concurrently.