### PR TITLE
README.md: link to new wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ IHaskell is regularly updated to work with the latest version of GHC. To read ho
 
 ## Nix flake
 
-There is also a Nix flake that provides a developer environment. For details on Nix flakes, please see the documentation at https://nixos.wiki/wiki/Flakes.
+There is also a Nix flake that provides a developer environment. For details on Nix flakes, please see the documentation at https://wiki.nixos.org/wiki/Flakes.
 
 After this, IHaskell can be compiled as follows:
 


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113