### PR TITLE
Make parseString not require Ghc monad

### DIFF
--- a/src/IHaskell/Eval/Evaluate.hs
+++ b/src/IHaskell/Eval/Evaluate.hs
@@ -438,7 +438,7 @@ evaluate :: KernelState                  -- ^ The kernel state.
 evaluate kernelState code output widgetHandler = do
   flags <- getSessionDynFlags
   (cmds, flags') <- liftIO $ flip runStateT flags $ parseString (cleanString code)
-  setSessionDynFlags flags'
+  void $ setSessionDynFlags flags'
 
   let execCount = getExecutionCounter kernelState
 

--- a/src/IHaskell/Eval/Util.hs
+++ b/src/IHaskell/Eval/Util.hs
@@ -33,6 +33,8 @@ import           IHaskellPrelude
 import qualified Data.ByteString.Char8 as CBS
 #endif
 
+import           Control.Monad.Trans.State
+
 -- GHC imports.
 #if MIN_VERSION_ghc(9,8,0)
 import           GHC.Core.InstEnv (is_cls, is_tys, mkInstEnv, instEnvElts)
@@ -294,13 +296,12 @@ pprLanguages show_all dflags =
 
 -- | Set an extension and update flags. Return @Nothing@ on success. On failure, return an error
 -- message.
-setExtension :: GhcMonad m => String -> m (Maybe String)
+setExtension :: String -> StateT DynFlags IO (Maybe String)
 setExtension ext = do
-  flags <- getSessionDynFlags
   case extensionFlag ext of
     Nothing -> return $ Just $ "Could not parse extension name: " ++ ext
     Just flag -> do
-      _ <- setSessionDynFlags $
+      modify $ \flags ->
         case flag of
           SetFlag ghcFlag   -> xopt_set flags ghcFlag
           UnsetFlag ghcFlag -> xopt_unset flags ghcFlag


### PR DESCRIPTION
I've been using IHaskell's [parseString](https://hackage.haskell.org/package/ihaskell-0.11.0.0/docs/IHaskell-Eval-Parser.html#v:parseString) function, and noticed that it's quite slow, taking several milliseconds just to parse a single line of code.

The reason is that it runs in the [Ghc](https://hackage.haskell.org/package/ghc-9.2.4/docs/GHC-Driver-Monad.html#t:Ghc) monad.  It's quite expensive to call [runGhc](https://hackage.haskell.org/package/ghc-9.2.4/docs/GHC.html#v:runGhc) just to parse a line of code, since it spins up a whole GHC session.

Fortunately, `parseString` doesn't actually make use of many of the `Ghc` monad's capabilities. The only functions it uses are `getSessionDynFlags` and `setSessionDynFlags`. Furthermore, it resets these flags when it's done parsing. So the only purpose for this state within the parsing code is to enable/disable extensions etc. while parsing.

Thus, we can replace the `Ghc` monad with a simple `StateT DynFlags IO`. This makes it *much* faster to do one-off parsing, with the time for me going from ~5 milliseconds to ~20 microseconds.