### PR TITLE
Update `haskell/actions/setup` to `haskell-actions/setup`.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -48,7 +48,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
 
-    - uses: haskell/actions/setup@v2
+    - uses: haskell-actions/setup@v2
       name: Setup Haskell Stack
       with:
         enable-stack: true


### PR DESCRIPTION
Other instances of `haskell/actions/setup` had already been migrated to `haskell-actions/setup`, but the one for the Docker action remained, so it is the only remaining instance of the use of the deprecated `haskell/actions/setup` action.