### PR TITLE
Fix cell numbering (#1417) by separating shell and control reply channels

### DIFF
--- a/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
+++ b/ipython-kernel/src/IHaskell/IPython/EasyKernel.hs
@@ -150,11 +150,11 @@ easyKernel profileFile config = do
   zmq <- liftIO $ serveProfile prof False
   execCount <- liftIO $ newMVar 0
   forever $ do
-    req <- liftIO $ readChan (shellRequestChannel zmq)
+    (repChan, req) <- liftIO $ readChan (shellRequestChannel zmq)
     repHeader <- createReplyHeader (header req)
     when (debug config) . liftIO $ print req
     reply <- replyTo config execCount zmq req repHeader
-    liftIO $ writeChan (shellReplyChannel zmq) reply
+    liftIO $ writeChan repChan reply
 
 replyTo :: MonadIO m
         => KernelConfig m output result

--- a/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
+++ b/ipython-kernel/src/IHaskell/IPython/ZeroMQ.hs
@@ -42,6 +42,10 @@ data ZeroMQInterface =
        Channels
          {
          -- | A channel populated with requests from the frontend.
+         -- Shared between the shell and control channels.
+         -- The channel content is a tuple (replyChannel, message):
+         --   * If the message comes from the shell channel, 'replyChannel' is the shell reply channel.
+         --   * If the message comes from the control channel, 'replyChannel' is the control reply channel.
          shellRequestChannel :: Chan (Chan Message, Message)
          -- | Writing to this channel causes a reply to be sent to the frontend.
          , shellReplyChannel :: Chan Message


### PR DESCRIPTION
This PR fixes issue #1417 where cell execution numbers were not updating correctly. The root cause was that replies meant for the `control` channel were interfering with `execute_reply` messages on the `shell` channel due to a shared reply channel (`Chan`). The fix separates the reply channels for `shell` and `control` and modifies the message passing to ensure replies are sent back to the correct handler.

## Problem Cause

As discovered in [#1506](https://github.com/IHaskell/IHaskell/issues/1506), the direct cause of the problem is that the IHaskell kernel does not send the `execute_reply` message to the frontend. This prevents the Jupyter frontend from knowing when a cell execution has finished. This primarily occurs because the IHaskell implementation mixes messages from two different channels -- `shell` and `control`. Specifically, replies sent via the `shell` channel's reply mechanism get mixed up with replies that should have been sent via the `control` channel. This is somewhat complex; let's break down what's happening.

### Hypothesis

In the IHaskell kernel implementation, theoretically, the `execute_reply` message *should* be sent. We can see the relevant code:

```haskell
-- Main.hs, line 308 - 350

-- Reply to an execution request. The reply itself does not require computation, but this causes
-- messages to be sent to the IOPub socket with the output of the code in the execution request.
replyTo _ interface req@ExecuteRequest { getCode = code } replyHeader state = do
  -- Convenience function to send a message to the IOPub socket.
  ...
  -- Take pager output if we're using the pager.
  pager <- if usePager state
             then liftIO $ readMVar pOut
             else return []
  return
    (updatedState, ExecuteReply
                      { header = replyHeader
                      , pagerOutput = pager
                      , executionCounter = execCount
                      , status = executeReplyStatus
                      })
```

This `replyTo` function is invoked in `main/Main.hs`, lines 193-228.

```haskell
    forever $ do
      -- Read the request from the request channel.
      request <- liftIO $ readChan $ shellRequestChannel interface

      ...
      if isCommMessage request
        then do
          ...
          liftIO $ writeChan (shellReplyChannel interface) SendNothing
        else do
          ...
          (newState, reply) <- replyTo kOpts interface request replyHeader oldState
          liftIO $ putMVar state newState

          -- Write the reply to the reply channel.
          liftIO $ writeChan (shellReplyChannel interface) reply
```

An ideal execution flow is: `request <- liftIO $ readChan $ shellRequestChannel interface` receives a request, and then `writeChan (shellReplyChannel interface)` writes its reply.

However, the observed behavior is that the `execute_reply` corresponding to the `execute_request` is not received by the frontend. It isn't even actually sent to ZMQ by the kernel's `shell` handler at the expected time.

`writeChan (shellReplyChannel interface)` writes to a Haskell `Chan` used for inter-thread communication within IHaskell. In practice, the `shell` and `control` functions running in separate threads read replies from their respective reply channels (`shellReplyChannel` and `controlReplyChannel`).

```haskell
-- ipython-kernel/src/IHaskell/IPython/

shell :: Bool -> ZeroMQInterface -> Socket Router -> IO ()
shell debug channels sock = do
  -- Receive a message and write it to the interface channel.
  receiveMessage debug sock >>= writeChan requestChannel

  -- Read the reply from the interface channel and send it.
  readChan replyChannel >>= sendMessage debug (hmacKey channels) sock

  where
    requestChannel = shellRequestChannel channels
    replyChannel = shellReplyChannel channels

control :: Bool -> ZeroMQInterface -> Socket Router -> IO ()
control debug channels sock = do
  -- Receive a message and write it to the interface channel.
  receiveMessage debug sock >>= writeChan requestChannel

  -- Read the reply from the interface channel and send it.
  readChan replyChannel >>= sendMessage debug (hmacKey channels) sock

  where
    requestChannel = controlRequestChannel channels
    replyChannel = controlReplyChannel channels
```

The path for handling an `execute_request` should be:

1.  The `shell` function receives an `execute_request` and sends it to `Main.hs` via `writeChan requestChannel`.
2.  `Main.hs` receives the `execute_request`, processes it, generates the `execute_reply`, and sends it back via `writeChan` (to `shellReplyChannel`).
3.  The `shell` function reads the `execute_reply` sent by `Main.hs` via `readChan replyChannel`.
4.  The `shell` function sends the `execute_reply` to the frontend.

The problem lies in step 3. Theoretically, we'd expect the content read by `shell` via `readChan replyChannel` to be the `execute_reply`. However, the implementation does not guarantee this. As long as there is *any* data in the `shellReplyChannel`, it will be read out. Furthermore, during each interaction cycle, `shell` reads only the *single earliest* message from the `shellReplyChannel`.

If the `shellReplyChannel` gets mixed with other data, the `execute_reply` might not be read when the `shell` handler is expecting it after processing the `execute_request`.

So, what other data might get mixed into `shellReplyChannel`? We notice that `controlReplyChannel` were created using `dupChan shellRepChan`, making them effectively the *same* shared broadcast channel:

```haskell
-- | Create new channels for a ZeroMQInterface
newZeroMQInterface :: ByteString -> IO ZeroMQInterface
newZeroMQInterface key = do
  shellReqChan <- newChan
  shellRepChan <- newChan
  controlReqChan <- dupChan shellReqChan -- Request channels are duplicated (shared read)
  controlRepChan <- dupChan shellRepChan -- << PROBLEM: Reply channels are ALSO duplicated
  iopubChan <- newChan
  return $! Channels
    { shellRequestChannel = shellReqChan
    , shellReplyChannel = shellRepChan
    , controlRequestChannel = controlReqChan
    , controlReplyChannel = controlRepChan -- This is the same Chan as shellReplyChannel
    , iopubChannel = iopubChan
    , hmacKey = key
    }
```

Thus, a very natural hypothesis is: when `Main.hs` processes data from the `control` channel (e.g., a `KernelInfoRequest`), it writes the reply (e.g., `KernelInfoReply`) to the *shared* reply channel (`shellReplyChannel`/`controlReplyChannel`). Consequently, when the `shell` handler processes an `execute_request` and tries to read its reply, it might instead read:

1.  A reply intended for the `control` channel.
2.  A stale reply from a *previous* `shell` channel request.

As a result, the IHaskell kernel might send an incorrect reply message (or no reply at the correct time) when processing an `execute_request`.

### Debugging Log Confirmation

I created a [debug](https://github.com/ayanamists/IHaskell/tree/debug) branch and added logging statements in `Main.hs`, `shell`, and `control`. The [log output](https://github.com/ayanamists/IHaskell/blob/debug/problem.log) confirms my hypothesis.

Lines 209, 211 show:
```
Shell request received: ExecuteRequest {header = MessageHeader {mhIdentifiers = [...], mhMsgType = ExecuteRequestMessage, ...}, getCode = "-- First of all, we can evaluate simple expressions.\n3 + 5\n\"Hello, \" ++ \"World!\"", ...}

Shell message will be sent: KernelInfoReply {header = MessageHeader {mhIdentifiers = [...], mhParentHeader = Just (MessageHeader {..., mhMsgType = KernelInfoRequestMessage}), ..., mhMsgType = KernelInfoReplyMessage}, protocolVersion = "5.0", ...}
```

This is a typical example of the issue: the `shell` handler received an `ExecuteRequest`, but instead of waiting for and sending the corresponding `ExecuteReply`, it immediately read and sent a `KernelInfoReply` from the shared reply channel.

This `KernelInfoReply` actually corresponds to a `KernelInfoRequest` message processed shortly before, which arrived on the *control* channel (lines 172, 176) and whose reply was written to the shared reply channel by `Main.hs` (line 181):

Line 172:
```
Control request received: KernelInfoRequest {header = MessageHeader {..., mhMsgType = KernelInfoRequestMessage}}
```

Line 176:
```
Main.hs: read shell request: KernelInfoRequest {header = MessageHeader {..., mhMsgType = KernelInfoRequestMessage}}
```
*(Note: Although received on the control socket, it reads from the duplicated `shellRequestChannel`)*

Line 181:
```
Main.hs: write shell reply: KernelInfoReply {header = MessageHeader {..., mhParentHeader = Just (MessageHeader {..., mhMsgType = KernelInfoRequestMessage}), ..., mhMsgType = KernelInfoReplyMessage}, ...}
```
*(Note: Writes the reply to the duplicated `shellReplyChannel`)*

## The Fix

Given that processing each message in `Main.hs` can potentially update the global state, merging the *input* (request) messages from `control` and `shell` via a broadcast request channel seems reasonable. However, sharing the *output* (reply) channel using `dupChan` is the source of the problem.

Therefore, the fix involves ensuring the reply channels are separate and that replies are routed back correctly.

First, I modified `newZeroMQInterface` so that `controlRepChan` and `shellRepChan` are distinct channels (using `newChan` for both, instead of `dupChan` for `controlRepChan`):

```haskell
-- | Create new channels for a ZeroMQInterface
newZeroMQInterface :: ByteString -> IO ZeroMQInterface
newZeroMQInterface key = do
  shellReqChan <- newChan
  shellRepChan <- newChan             -- Separate Shell Reply Chan
  controlReqChan <- dupChan shellReqChan -- Request channel is still shared (broadcast read)
  controlRepChan <- newChan             -- << FIX: Separate Control Reply Chan
  iopubChan <- newChan
  return $! Channels
    { shellRequestChannel = shellReqChan
    , shellReplyChannel = shellRepChan
    , controlRequestChannel = controlReqChan
    , controlReplyChannel = controlRepChan -- Now distinct from shellReplyChannel
    , iopubChannel = iopubChan
    , hmacKey = key
    }
```

Second, to ensure `Main.hs` sends the reply to the *correct* channel (`shellReplyChannel` or `controlReplyChannel`), the shared request channel (`shellRequestChannel` / `controlRequestChannel`) is modified to carry not just the `Message` but also a reference to the specific `Chan Message` that should be used for the reply.

I modified the type definition within `ZeroMQInterface`:

```haskell
        shellRequestChannel   :: Chan (Chan Message, Message) -- Carries (Reply Channel, Request Message)
        controlRequestChannel :: Chan (Chan Message, Message) -- Carries (Reply Channel, Request Message)
```

And updated the `shell` and `control` handlers to package the correct reply channel along with the request message when writing to the shared request channel:

```haskell
-- In shell function:
  receiveMessage debug sock >>= \msg -> writeChan requestChannel (replyChannel, msg) -- Pass (shellReplyChannel, msg)

-- In control function:
  receiveMessage debug sock >>= \msg -> writeChan requestChannel (replyChannel, msg) -- Pass (controlReplyChannel, msg)
```

Finally, the main processing loop in `Main.hs` is updated to read this tuple and use the provided reply channel:

```haskell
      -- Read the request and its designated reply channel from the request channel.
      (repChan, request) <- liftIO $ readChan $ shellRequestChannel interface -- Gets the tuple

      ...
      if isCommMessage request
        then do
          ...
          liftIO $ writeChan repChan SendNothing -- << FIX: Write reply to specific repChan
        else do
          ...
          (newState, reply) <- replyTo kOpts interface request replyHeader oldState
          liftIO $ putMVar state newState

          -- Write the reply to the correct reply channel.
          liftIO $ writeChan repChan reply       -- << FIX: Write reply to specific repChan
```

These changes ensure that replies for the `shell` and `control` channel messages are routed back to their respective handler threads (`shell` or `control`) via separate, dedicated reply channels. This prevents the mixing of replies and allows the `shell` handler to correctly receive and send the `execute_reply` message, enabling the frontend to properly display the execution count (cell numbers).

Execution after this fix:


https://github.com/user-attachments/assets/fcf1910b-5067-4a58-913c-2995e0cb2093

