### PR TITLE
chore: Update stack/docker GHC version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # should match the GHC version of the stack.yaml resolver
 # checked in CI
-ARG GHC_VERSION=9.6.4
+ARG GHC_VERSION=9.6.7
 
 FROM haskell:${GHC_VERSION} AS ihaskell_base
 
@@ -56,21 +56,21 @@ RUN pip3 install -U pip
 RUN pip3 install -U jupyterlab notebook
 
 # Create runtime user
-ENV NB_USER jovyan
-ENV NB_UID 1000
+ENV NB_USER=jovyan
+ENV NB_UID=1000
 RUN adduser --disabled-password \
     --gecos "Default user" \
     --uid ${NB_UID} \
     ${NB_USER}
 
 # Create directory for storing ihaskell files
-ENV IHASKELL_DATA_DIR /usr/local/lib/ihaskell
+ENV IHASKELL_DATA_DIR=/usr/local/lib/ihaskell
 RUN mkdir -p ${IHASKELL_DATA_DIR} && chown ${NB_UID} ${IHASKELL_DATA_DIR}
 
 # Set up + set hlint data directory
-ENV HLINT_DATA_DIR /usr/local/lib/hlint
+ENV HLINT_DATA_DIR=/usr/local/lib/hlint
 COPY --from=builder --chown=${NB_UID} /data/hlint.yaml ${HLINT_DATA_DIR}/
-ENV hlint_datadir ${HLINT_DATA_DIR}
+ENV hlint_datadir=${HLINT_DATA_DIR}
 
 # Set current user + directory
 WORKDIR /home/${NB_USER}/src

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.10 # GHC 9.6.4
+resolver: lts-22.44 # GHC 9.6.7
 
 packages:
 - .

--- a/stack/stack-9.6.yaml
+++ b/stack/stack-9.6.yaml
@@ -1,4 +1,4 @@
-resolver: lts-22.10 # GHC 9.6.4
+resolver: lts-22.44 # GHC 9.6.7
 
 packages:
 - ..


### PR DESCRIPTION
Haskell's GHC 9.6.4 image runs on debian buster which is near its EOL. All its packages have been moved from the main debian repo/url to the archive.debian repo/url. This means that trying to run `sudo apt update` fails.

GHC 9.6.7's image is still up to date.

Also update Dockerfile warning about legacy environment variable setting.